### PR TITLE
Updating microsoft azure packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,25 @@ Wrap the code inside the handler as followed:
 ```java
 import com.signalfx.azurefunctions.wrapper.MetricWrapper;
 
-@FunctionName("Hello-SignalFx")
-public HttpResponseMessage<String> hello(HttpRequestMessage<Optional<String>> request,
-                final ExecutionContext context) {
-        MetricWrapper wrapper = new MetricWrapper(context);
-            ...
-            // your code
-            ...
-        } catch (Exception e) {
-          wrapper.error();
-        } finally {
-          wrapper.close();
-        }
+public class Function {
+    @FunctionName("Hello-SignalFx")
+      @HttpTrigger(
+          name = "req",
+          methods = {HttpMethod.GET, HttpMethod.POST},
+          authLevel = AuthorizationLevel.ANONYMOUS)
+          HttpRequestMessage<Optional<String>> request,
+          final ExecutionContext context) {
+              context.getLogger().info("Java HTTP trigger processed a request.");
+              try (MetricWrapper wrapper = new MetricWrapper(context)) {
+                  ...
+                  // your code
+                  ...
+              } catch (Exception e) {
+                wrapper.error();
+              } finally {
+                wrapper.close();
+              }
+      }
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.signalfx.public</groupId>
@@ -121,9 +119,9 @@
             <id>test</id>
             <dependencies>
                 <dependency>
-                  <groupId>com.microsoft.azure</groupId>
-                  <artifactId>azure-functions-java-core</artifactId>
-                  <version>[1.0.0-beta-1,1.0.0)</version>
+                    <groupId>com.microsoft.azure.functions</groupId>
+                    <artifactId>azure-functions-java-library</artifactId>
+                    <version>1.4.0</version>
                 </dependency>
             </dependencies>
             <build>
@@ -161,9 +159,9 @@
             <version>1.7.25</version>
         </dependency>
         <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-functions-java-core</artifactId>
-                <version>[1.0.0-beta-1,1.0.0)</version>
+            <groupId>com.microsoft.azure.functions</groupId>
+            <artifactId>azure-functions-java-library</artifactId>
+            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.signalfx.public</groupId>

--- a/src/java/com/signalfx/azurefunctions/example/Function.java
+++ b/src/java/com/signalfx/azurefunctions/example/Function.java
@@ -2,8 +2,8 @@ package com.signalfx.azurefunctions.example;
 
 import java.util.*;
 import java.io.IOException;
-import com.microsoft.azure.serverless.functions.annotation.*;
-import com.microsoft.azure.serverless.functions.*;
+import com.microsoft.azure.functions.annotation.*;
+import com.microsoft.azure.functions.*;
 import com.signalfx.azurefunctions.wrapper.MetricWrapper;
 import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 
@@ -17,8 +17,12 @@ public class Function {
          * 2. curl {your host}/api/hello?name=HTTP%20Query
          */
         @FunctionName("Hello-Signalfx")
-        public HttpResponseMessage<String> hello(
-                        @HttpTrigger(name = "req", methods = {"get", "post"}, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
+        public HttpResponseMessage hello(
+                        @HttpTrigger(
+                            name = "req", 
+                            methods = {HttpMethod.GET, HttpMethod.POST}, 
+                            authLevel = AuthorizationLevel.ANONYMOUS) 
+                            HttpRequestMessage<Optional<String>> request,
                         final ExecutionContext context) {
                 try (MetricWrapper wrapper = new MetricWrapper(context)) {
                     try {
@@ -26,10 +30,10 @@ public class Function {
                         String name = request.getBody().orElse(query);
 
                             if (name == null) {
-                            return request.createResponse(400, "Please pass a name on the query string or in the request body");
-                        } else {
-                            return request.createResponse(200, "Hello, " + name);
-                        }
+                                return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
+                            } else {
+                                return request.createResponseBuilder(HttpStatus.OK).body( "Hello, " + name).build();
+                            }
                     } catch (Exception e) {
                         wrapper.error();
                     } finally {
@@ -38,6 +42,6 @@ public class Function {
                 } catch (IOException e) {
                     context.getLogger().warning("Exception thrown closing wrapper");
                 }
-                return request.createResponse(200, "Hello");
+                return request.createResponseBuilder(HttpStatus.OK).body("Hello").build();
         }
 }

--- a/src/java/com/signalfx/azurefunctions/wrapper/MetricWrapper.java
+++ b/src/java/com/signalfx/azurefunctions/wrapper/MetricWrapper.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import com.microsoft.azure.serverless.functions.ExecutionContext;
+import com.microsoft.azure.functions.ExecutionContext;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.signalfx.metrics.auth.StaticAuthToken;

--- a/src/test/java/com/signalfx/azurefunctions/wrapper/test/TestCustomHandler.java
+++ b/src/test/java/com/signalfx/azurefunctions/wrapper/test/TestCustomHandler.java
@@ -5,7 +5,7 @@ package com.signalfx.azurefunctions.wrapper.test;
 
 import java.util.Map;
 
-import com.microsoft.azure.serverless.functions.ExecutionContext;
+import com.microsoft.azure.functions.ExecutionContext;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.signalfx.azurefunctions.wrapper.MetricSender;


### PR DESCRIPTION
## Issue
While building our Azure Function apps our team attempted to use the wrapper on the [Microsoft Azure Java Function Tutorial](https://docs.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java?tabs=bash%2Cazure-cli%2Cbrowser) referenced in the README.md of this repository.

We followed the README.md instructions as described to wrap the function in the wrapper.

Expected behavior:

On mvn clean, install the function will compile and generate a jar file. 

Actual behavior:
```console
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project fabrikam-functions: Compilation failure
[ERROR] /C:/Src/azure-functions/fabrikam-functions/src/main/java/com/fabrikam/Function.java:[35,56] incompatible types: com.microsoft.azure.functions.ExecutionContext cannot be converted to com.microsoft.azure.serverless.functions.ExecutionContext
```

## Change

While investigating this issue, it was discovered taht Microsoft depricated (or removed) a previous package class "com.microsoft.azure.serverles.functions". This package is used by the class MetricWrapper.java in this repo (alogn with the example function and the test class). 

### src
The following files have been updated in the **src** folder to use the new package "com.microsoft.azure.functions" and the associated updated methods (also minor formatting updates):

- java/com/signalfx/azurefunctions/
  - example/Function.java
  - wrapper/MetricWrapper.java
- test/java/comsignlafx/azurefunctions/
  -TestCustomHandler.java

### pom.xml

The pom.xml file has been updated to reference the newer Microsoft dependency in both main dependencies and the test dependencies. **The pom project version was *not* updated as it appears there is a py script to handle this**

### README.md

The readme has been updated to reflect the new invocation of the new package classes. 

## Test

This change was tested locally by building the maven project and creating a **0.0.2** version in the local .m2 repository. That version was then packaged into a test function and deployed to Azure through VS Code. The function was then invoked and it was verified that MTS data from the function was visible in the **(SignalFX) Azure Function** dashboard. 


 